### PR TITLE
avoid path roads and service roads

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,7 @@ test('crossingHighways', function(t) {
 });
 
 test('unconnectedHighways', function(t) {
-  t.plan(3);
+  t.plan(2);
   logInterceptor();
   processors.unconnectedHighways(opts, unconnectedhighwaysTiles, function() {
     var logs = logInterceptor.end();
@@ -195,7 +195,6 @@ test('unconnectedHighways', function(t) {
       if (geoJSON.features.length > 0) {
         t.equal(geoJSON.features[0].properties._osmlint, 'unconnectedhighways', 'Should be unconnectedhighways');
         t.equal(geoJSON.features[0].geometry.type, 'LineString', 'Should be LineString');
-        t.equal(geoJSON.features[5].geometry.type, 'Point', 'Should be Point');
       }
     }
     t.end();

--- a/validators/unconnectedHighways/map.js
+++ b/validators/unconnectedHighways/map.js
@@ -26,7 +26,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     'unclassified': true,
     'residential': true,
     'living_street': true,
-    'service': true,
+    // 'service': true,
     'road': true
   };
   var pathRoads = {
@@ -40,7 +40,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
   var preserveType = {};
   preserveType = _.extend(preserveType, majorRoads);
   preserveType = _.extend(preserveType, minorRoads);
-  preserveType = _.extend(preserveType, pathRoads);
+  // preserveType = _.extend(preserveType, pathRoads);
   var unit = 'meters';
   var distance = 5;
   var highways = {};


### PR DESCRIPTION
The change here is to avoid the path and service roads to run faster the validation, and focus on minor unclassified, residential, living streets and road. in minor classification.
if you want to detect path roads and service, just uncommented the follow lines on [map.js](https://github.com/osmlab/osmlint/blob/master/validators/unconnectedHighways/map.js) file. 

```
// 'service': true,
// preserveType = _.extend(preserveType, pathRoads);
```

cc @geohacker @planemad @maning