### PR TITLE
Adds back service roads in some validators related to conncetivity

### DIFF
--- a/validators/impossibleAngle/map.js
+++ b/validators/impossibleAngle/map.js
@@ -22,8 +22,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    service: true,
-    road: true
+    service: true
+//    road: true
   };
   var pathRoads = {
     pedestrian: true,

--- a/validators/impossibleAngle/map.js
+++ b/validators/impossibleAngle/map.js
@@ -22,7 +22,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    // 'service': true,
+    service: true,
     road: true
   };
   var pathRoads = {

--- a/validators/impossibleOneWays/map.js
+++ b/validators/impossibleOneWays/map.js
@@ -29,8 +29,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
   var minorRoads = {
     unclassified: true,
     residential: true,
-    living_street: true
-    // 'service': true,
+    living_street: true,
+    service: true
     // 'road': true
   };
   var pathRoads = {

--- a/validators/islandsHighways/map.js
+++ b/validators/islandsHighways/map.js
@@ -31,8 +31,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    service: true,
-    road: true
+    service: true
+    // road: true
   };
   var pathRoads = {
     pedestrian: true,

--- a/validators/islandsHighways/map.js
+++ b/validators/islandsHighways/map.js
@@ -31,7 +31,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    // 'service': true,
+    service: true,
     road: true
   };
   var pathRoads = {

--- a/validators/overlapHighways/map.js
+++ b/validators/overlapHighways/map.js
@@ -23,8 +23,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    service: true,
-    road: true
+    service: true
+    // road: true
   };
   var pathRoads = {
     pedestrian: true,

--- a/validators/overlapHighways/map.js
+++ b/validators/overlapHighways/map.js
@@ -23,7 +23,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    // 'service': true,
+    service: true,
     road: true
   };
   var pathRoads = {

--- a/validators/unconnectedHighways/map.js
+++ b/validators/unconnectedHighways/map.js
@@ -28,7 +28,7 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    // 'service': true,
+    service: true,
     road: true
   };
   var pathRoads = {

--- a/validators/unconnectedHighways/map.js
+++ b/validators/unconnectedHighways/map.js
@@ -28,8 +28,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
     unclassified: true,
     residential: true,
     living_street: true,
-    service: true,
-    road: true
+    service: true
+    //road: true
   };
   var pathRoads = {
     pedestrian: true,


### PR DESCRIPTION
We should also fix routing/connectivity issues with `service` roads, this PR adds it back.

The following validators are:
* impossibleAngle
* impossibleOneWays
* islandsHighways
* overlapHighways
* unconnectedHighways

@srividyacb