### PR TITLE
add multipoint support to overlapHighways linter

### DIFF
--- a/validators/overlapHighways/map.js
+++ b/validators/overlapHighways/map.js
@@ -126,6 +126,11 @@ module.exports = function(tileLayers, tile, writeData, done) {
                 props
               );
             }
+          } else if (intersect.geometry.type === 'MultiPoint') {
+            for (l = 0; l < coordinates.length; l++) {
+              coor = coordinates[l];
+              output[coor] = turf.point(coor, props);
+            }
           } else {
             output[coordinates] = turf.point(coordinates, props);
           }

--- a/validators/overlapHighways/map.js
+++ b/validators/overlapHighways/map.js
@@ -65,10 +65,8 @@ module.exports = function(tileLayers, tile, writeData, done) {
         var fromHighway = highways[bbox.id];
         var toHighway = highways[overlap.id];
         var intersect = turf.lineIntersect(toHighway, fromHighway);
-        if (intersect && intersect.features.length > 0) {
-          if (intersect.features.length > 1) {
-            intersect = turf.combine(intersect);
-          }
+        if (intersect && intersect.features.length > 1) {
+          intersect = turf.combine(intersect);
           intersect = intersect.features[0];
           // if (intersect.geometry.type === 'LineString' || intersect.geometry.type === 'MultiLineString') {
           var coordinates = intersect.geometry.coordinates;


### PR DESCRIPTION
closes #271 

## to test
run the overlapHighways linter on data that contains multipoint features

## questions/thoughts
Is there a tool for editing/creating fixture qa-tile data?
would it be useful to start testing linters against generic qa tile data, as well as fixtured data tailored to each test case?
