### PR TITLE
adding opinionated postProcessing flag to certain linters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -37,9 +37,11 @@ var usage = function() {
   }
   var bbox = argv.bbox ? JSON.parse(argv.bbox) : null;
   var zoom = argv.zoom ? parseInt(argv.zoom) : 12;
+  var postProcess = !!argv.p;
   var opts = {
     bbox: bbox,
-    zoom: zoom
+    zoom: zoom,
+    postProcess: postProcess
   };
   validator.apply(null, [opts].concat(argv._.slice(1)));
 })();

--- a/lib/postProcessing.js
+++ b/lib/postProcessing.js
@@ -19,11 +19,7 @@ function createReadlineStream() {
 }
 
 function createGeometryFilterTypeStream(types) {
-  if (types) {
-    types = ['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon'];
-  }
   var transform = new stream.Transform();
-
   transform._transform = function (line, encoding, done) {
     var obj = JSON.parse(line.toString());
     var features = [];

--- a/lib/postProcessing.js
+++ b/lib/postProcessing.js
@@ -1,0 +1,137 @@
+'use strict';
+var stream = require('stream');
+var turf = require('@turf/turf');
+
+function createReadlineStream() {
+  var transform = new stream.Transform();
+  var lineBuffer = '';
+  transform._transform = function (data, encoding, done) {
+    var lines = data.toString().split('\n');
+    lines[0] = lineBuffer + lines[0];
+    lineBuffer = lines.pop();
+    var output = '';
+    lines.forEach(function(line) {
+      output += line + '\n';
+    });
+    done(null, output);
+  };
+  return transform;
+}
+
+function createGeometryFilterTypeStream(types) {
+  if (types) {
+    types = ['Point', 'MultiPoint', 'LineString', 'MultiLineString', 'Polygon', 'MultiPolygon'];
+  }
+  var transform = new stream.Transform();
+
+  transform._transform = function (line, encoding, done) {
+    var obj = JSON.parse(line.toString());
+    var features = [];
+    for (var i = 0; i < obj.features.length; i++) {
+      if (types.indexOf(obj.features[i].geometry.type) > -1) {
+        features.push(obj.features[i]);
+      }
+    }
+    if (features.length > 0) {
+      var geojson = {
+        type: 'FeatureCollection',
+        features: features
+      };
+      this.push(JSON.stringify(geojson));
+    }
+    done();
+  };
+  return transform;
+}
+
+function createConvertToGeojsonStream() {
+  var geojson = {
+    'type': 'FeatureCollection',
+    'features': []
+  };
+  var transform = new stream.Transform();
+  transform._transform = function (line, encoding, done) {
+    var obj = JSON.parse(line.toString());
+    if (obj.type === 'FeatureCollection') {
+      geojson.features = geojson.features.concat(obj.features);
+    } else {
+      geojson.features = geojson.features.concat(obj);
+    }
+    done();
+  };
+  transform._flush = function (done) {
+    this.push(JSON.stringify(geojson));
+    done();
+  };
+  return transform;
+}
+
+function createMergeByIdStream() {
+  var transform = new stream.Transform();
+  transform._transform = function (line, encoding, done) {
+    var obj = JSON.parse(line);
+    var result = {};
+    var features = obj.features;
+    for (var i = 0; i < features.length; i++) {
+      var val = features[i];
+      if (val.geometry.type === 'Point') {
+        var id = val.properties._fromWay + ',' + val.properties._toWay;
+        if (!result[id]) {
+          result[id] = [val];
+        } else {
+          result[id].push(val);
+        }
+      }
+    }
+    var geojson = {
+      'type': 'FeatureCollection',
+      'features': []
+    };
+    var values = Object.keys(result).map(function(e) {
+      return result[e];
+    });
+    values.forEach(function (val) {
+      var points = {
+        'type': 'FeatureCollection',
+        'features': val
+      };
+      var multipoints = turf.combine(points);
+      multipoints.features[0].properties = val[0].properties;
+      geojson.features.push(multipoints.features[0]);
+    });
+    this.push(JSON.stringify(geojson) + '\n');
+    done();
+  };
+  return transform;
+}
+
+function createToMultipointStream() {
+  var transform = new stream.Transform();
+  transform._transform = function (line, encoding, done) {
+    var obj = JSON.parse(line);
+    var geojson = {
+      'type': 'FeatureCollection',
+      'features': []
+    };
+    for (var i = 0; i < obj.features.length; i++) {
+      if (obj.features[i].geometry.type === 'LineString' || obj.features[i].geometry.type === 'Polygon') {
+        var multipoints = turf.combine(turf.explode(obj.features[i]));
+        multipoints.features[0].properties = obj.features[i].properties;
+        geojson.features.push(multipoints.features[0]);
+      } else {
+        geojson.features.push(obj.features[i]);
+      }
+    }
+    this.push(JSON.stringify(geojson) + '\n');
+    done();
+  };
+  return transform;
+}
+
+module.exports = {
+  createReadlineStream: createReadlineStream,
+  createGeometryFilterTypeStream: createGeometryFilterTypeStream,
+  createConvertToGeojsonStream: createConvertToGeojsonStream,
+  createMergeByIdStream: createMergeByIdStream,
+  createToMultipointStream: createToMultipointStream
+};

--- a/test/crossingHighways.test.js
+++ b/test/crossingHighways.test.js
@@ -8,13 +8,44 @@ var crossingHighwaysTiles = path.join(
   __dirname,
   '/fixtures/crossingHighways.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
 
 test('crossingHighways', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.crossingHighways(commonOpts, crossingHighwaysTiles, function() {
+    var logs = logInterceptor.end();
+    for (var i = 0; i < logs.length; i++) {
+      var geoJSON = JSON.parse(logs[i]);
+      t.comment('Pass: ' + (i + 1));
+      if (geoJSON.features.length > 0) {
+        t.equal(
+          geoJSON.features[0].properties._osmlint,
+          'crossinghighways',
+          'Should be crossinghighways'
+        );
+        t.equal(
+          geoJSON.features[0].geometry.type,
+          'LineString',
+          'Should be LineString'
+        );
+      }
+    }
+    t.end();
+  });
+});
+
+
+test('crossingHighways -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProccess: true
+  };
   logInterceptor();
   processors.crossingHighways(commonOpts, crossingHighwaysTiles, function() {
     var logs = logInterceptor.end();

--- a/test/crossingHighwaysBuildings.test.js
+++ b/test/crossingHighwaysBuildings.test.js
@@ -8,13 +8,13 @@ var crossingHighwaysBuildingsTiles = path.join(
   __dirname,
   '/fixtures/crossingHighwaysBuildings.mbtiles'
 );
-var crossingHighwaysBuildingsOpts = {
-  bbox: [119.97517, 23.447656, 121.52149, 24.726407],
-  zoom: zoom
-};
 
 test('crossingHighwaysBuildings', function(t) {
   t.plan(2);
+  var crossingHighwaysBuildingsOpts = {
+    bbox: [119.97517, 23.447656, 121.52149, 24.726407],
+    zoom: zoom
+  };
   logInterceptor();
   processors.crossinghighwaysbuildings(
     crossingHighwaysBuildingsOpts,
@@ -34,6 +34,42 @@ test('crossingHighwaysBuildings', function(t) {
             geoJSON.features[0].geometry.type,
             'LineString',
             'Should be LineString'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+
+test('crossingHighwaysBuildings -- postProcess', function(t) {
+  t.plan(2);
+  var crossingHighwaysBuildingsOpts = {
+    bbox: [119.97517, 23.447656, 121.52149, 24.726407],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.crossinghighwaysbuildings(
+    crossingHighwaysBuildingsOpts,
+    crossingHighwaysBuildingsTiles,
+    function() {
+      var logs = logInterceptor.end();
+      console.log(logs.length);
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        t.comment('Pass: ' + (i + 1));
+        if (geoJSON.features.length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'crossinghighwaysbuildings',
+            'Should be crossinghighwaysbuildings'
+          );
+          t.equal(
+            geoJSON.features[0].geometry.type,
+            'MultiPoint',
+            'Should be MultiPoint'
           );
         }
       }

--- a/test/deprecatedConstructionProposalTag.test.js
+++ b/test/deprecatedConstructionProposalTag.test.js
@@ -9,13 +9,40 @@ var tiles = path.join(
   __dirname,
   '/fixtures/deprecatedConstructionProposalTag.mbtiles'
 );
-var opts = {
-  bbox: [-117.15065, 33.530663, -117.07684, 33.57544],
-  zoom: zoom
-};
 
 test('Deprecated construction proposal tag', function(t) {
   t.plan(2);
+  var opts = {
+    bbox: [-117.15065, 33.530663, -117.07684, 33.57544],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.deprecatedConstructionProposalTag(opts, tiles, function() {
+    var logs = logInterceptor.end();
+    for (var i = 0; i < logs.length; i++) {
+      var geoJSON = JSON.parse(logs[i]);
+      t.equal(
+        geoJSON.features[0].properties._osmlint,
+        'deprecatedconstructionproposaltag',
+        'Should be deprecatedconstructionproposaltag'
+      );
+      t.equal(
+        geoJSON.features[0].properties['@id'],
+        113104928,
+        'Should be 113104928'
+      );
+    }
+    t.end();
+  });
+});
+
+test('Deprecated construction proposal tag -- postProcess', function(t) {
+  t.plan(2);
+  var opts = {
+    bbox: [-117.15065, 33.530663, -117.07684, 33.57544],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.deprecatedConstructionProposalTag(opts, tiles, function() {
     var logs = logInterceptor.end();

--- a/test/duplicateWayNameRef.test.js
+++ b/test/duplicateWayNameRef.test.js
@@ -8,13 +8,41 @@ var duplicatewaynamerefTiles = path.join(
   __dirname,
   '/fixtures/duplicatewaynameref.mbtiles'
 );
-var duplicatewaynamerefOpts = {
-  bbox: [-118.58282, 35.739546, -118.26834, 35.969393],
-  zoom: zoom
-};
 
 test('duplicatewaynameref', function(t) {
   t.plan(6);
+  var duplicatewaynamerefOpts = {
+    bbox: [-118.58282, 35.739546, -118.26834, 35.969393],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.duplicateWayNameRef(
+    duplicatewaynamerefOpts,
+    duplicatewaynamerefTiles,
+    function() {
+      var logs = logInterceptor.end();
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        if (logs[i].length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'duplicatewaynameref',
+            'Should be duplicatewaynameref'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+test('duplicatewaynameref -- postProcess', function(t) {
+  t.plan(1);
+  var duplicatewaynamerefOpts = {
+    bbox: [-118.58282, 35.739546, -118.26834, 35.969393],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.duplicateWayNameRef(
     duplicatewaynamerefOpts,

--- a/test/impossibleAngle.test.js
+++ b/test/impossibleAngle.test.js
@@ -8,13 +8,13 @@ var impossibleAngleTiles = path.join(
   __dirname,
   '/fixtures/impossibleAngle.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
 
 test('impossibleAngle', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
   logInterceptor();
   processors.impossibleAngle(commonOpts, impossibleAngleTiles, function() {
     var logs = logInterceptor.end();
@@ -31,6 +31,36 @@ test('impossibleAngle', function(t) {
           geoJSON.features[0].geometry.type,
           'LineString',
           'Should be LineString'
+        );
+      }
+    }
+    t.end();
+  });
+});
+
+test('impossibleAngle -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.impossibleAngle(commonOpts, impossibleAngleTiles, function() {
+    var logs = logInterceptor.end();
+    for (var i = 0; i < logs.length; i++) {
+      var geoJSON = JSON.parse(logs[i]);
+      t.comment('Pass: ' + (i + 1));
+      if (geoJSON.features.length > 0) {
+        t.equal(
+          geoJSON.features[0].properties._osmlint,
+          'impossibleangle',
+          'Should be impossibleangle'
+        );
+        t.equal(
+          geoJSON.features[0].geometry.type,
+          'Point',
+          'Should be Point'
         );
       }
     }

--- a/test/impossibleOneWays.test.js
+++ b/test/impossibleOneWays.test.js
@@ -8,18 +8,18 @@ var impossibleOneWaysTiles = path.join(
   __dirname,
   '/fixtures/impossibleOneways.mbtiles'
 );
-var impossibleOneWaysOpts = {
-  bbox: [
-    -81.75279225222766,
-    26.52308811583282,
-    -81.75209236331284,
-    26.52601005448122
-  ],
-  zoom: zoom
-};
 
 test('impossibleOneWays', function(t) {
   t.plan(2);
+  var impossibleOneWaysOpts = {
+    bbox: [
+      -81.75279225222766,
+      26.52308811583282,
+      -81.75209236331284,
+      26.52601005448122
+    ],
+    zoom: zoom
+  };
   logInterceptor();
   processors.impossibleOneWays(
     impossibleOneWaysOpts,
@@ -36,6 +36,40 @@ test('impossibleOneWays', function(t) {
         geoJSON.features[0].geometry.type,
         'LineString',
         'Should be  LineString'
+      );
+      t.end();
+    }
+  );
+});
+
+test('impossibleOneWays -- postProcess', function(t) {
+  t.plan(2);
+  var impossibleOneWaysOpts = {
+    bbox: [
+      -81.75279225222766,
+      26.52308811583282,
+      -81.75209236331284,
+      26.52601005448122
+    ],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.impossibleOneWays(
+    impossibleOneWaysOpts,
+    impossibleOneWaysTiles,
+    function() {
+      var logs = logInterceptor.end();
+      var geoJSON = JSON.parse(logs[0]);
+      t.equal(
+        geoJSON.features[0].properties._osmlint,
+        'impossibleoneways',
+        'Should be impossibleoneways'
+      );
+      t.equal(
+        geoJSON.features[0].geometry.type,
+        'Point',
+        'Should be  Point'
       );
       t.end();
     }

--- a/test/invalidDestination.test.js
+++ b/test/invalidDestination.test.js
@@ -5,13 +5,38 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var mbtile = path.join(__dirname, '/fixtures/invaliddestination.mbtiles');
-var opts = {
-  bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
-  zoom: zoom
-};
 
 test('invalidDestination', function(t) {
   t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.invalidDestination(opts, mbtile, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs[0]);
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'LineString',
+      'Should be LineString'
+    );
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'invaliddestination',
+      'Should be invaliddestination'
+    );
+    t.end();
+  });
+});
+
+test('invalidDestination -- postProcess', function(t) {
+  t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.invalidDestination(opts, mbtile, function() {
     var logs = logInterceptor.end();

--- a/test/invalidMotorwatJunction.test.js
+++ b/test/invalidMotorwatJunction.test.js
@@ -5,13 +5,35 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var mbtile = path.join(__dirname, '/fixtures/invalidmotorwayjunctions.mbtiles');
-var opts = {
-  bbox: [-96.944218, 32.636195, -96.55695, 32.917926],
-  zoom: zoom
-};
 
 test('invalidMotorwayJunctions', function(t) {
   t.plan(2);
+  var opts = {
+    bbox: [-96.944218, 32.636195, -96.55695, 32.917926],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.invalidMotorwayJunctions(opts, mbtile, function() {
+    var logs = logInterceptor.end();
+
+    var geoJSON = JSON.parse(logs[0]);
+    t.equal(geoJSON.features[0].geometry.type, 'Point', 'Should be Point');
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'invalidmotorwayjunctions',
+      'Should be invalidmotorwayjunctions'
+    );
+    t.end();
+  });
+});
+
+test('invalidMotorwayJunctions -- postProcess', function(t) {
+  t.plan(2);
+  var opts = {
+    bbox: [-96.944218, 32.636195, -96.55695, 32.917926],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.invalidMotorwayJunctions(opts, mbtile, function() {
     var logs = logInterceptor.end();

--- a/test/invalidTurnLanes.test.js
+++ b/test/invalidTurnLanes.test.js
@@ -5,13 +5,38 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var turnLanesTiles = path.join(__dirname, '/fixtures/invalidTurnLanes.mbtiles');
-var turnLaneOpts = {
-  bbox: [-97.418518, 34.672182, -97.128754, 34.869595],
-  zoom: zoom
-};
 
 test('invalidTurnLanes', function(t) {
   t.plan(2);
+  var turnLaneOpts = {
+    bbox: [-97.418518, 34.672182, -97.128754, 34.869595],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.invalidTurnLanes(turnLaneOpts, turnLanesTiles, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs[0]);
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'invalidturnlanes',
+      'Should be turnlanes'
+    );
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'LineString',
+      'Should be  LineString'
+    );
+    t.end();
+  });
+});
+
+test('invalidTurnLanes -- postProcess', function(t) {
+  t.plan(2);
+  var turnLaneOpts = {
+    bbox: [-97.418518, 34.672182, -97.128754, 34.869595],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.invalidTurnLanes(turnLaneOpts, turnLanesTiles, function() {
     var logs = logInterceptor.end();

--- a/test/islandsHighways.test.js
+++ b/test/islandsHighways.test.js
@@ -8,13 +8,43 @@ var islandsHighwaysTiles = path.join(
   __dirname,
   '/fixtures/islandsHighways.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
 
 test('islandsHighways', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.islandsHighways(commonOpts, islandsHighwaysTiles, function() {
+    var logs = logInterceptor.end();
+    for (var i = 0; i < logs.length; i++) {
+      var geoJSON = JSON.parse(logs[i]);
+      t.comment('Pass: ' + (i + 1));
+      if (geoJSON.features.length > 0) {
+        t.equal(
+          geoJSON.features[0].properties._osmlint,
+          'islandshighways',
+          'Should be islandsHighways'
+        );
+        t.equal(
+          geoJSON.features[0].geometry.type,
+          'LineString',
+          'Should be LineString'
+        );
+      }
+    }
+    t.end();
+  });
+});
+
+test('islandsHighways -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.islandsHighways(commonOpts, islandsHighwaysTiles, function() {
     var logs = logInterceptor.end();

--- a/test/missingCardinalDestination.js
+++ b/test/missingCardinalDestination.js
@@ -5,13 +5,38 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var mbtile = path.join(__dirname, '/fixtures/missingdestination.mbtiles');
-var opts = {
-  bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
-  zoom: zoom
-};
 
 test('missingCardinalDestination', function(t) {
   t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.missingCardinalDestination(opts, mbtile, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs[0]);
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'LineString',
+      'Should be LineString'
+    );
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'missingcardinaldestination',
+      'Should be missingCardinalDestination'
+    );
+    t.end();
+  });
+});
+
+test('missingCardinalDestination -- postProcess', function(t) {
+  t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.missingCardinalDestination(opts, mbtile, function() {
     var logs = logInterceptor.end();

--- a/test/missingDestination.test.js
+++ b/test/missingDestination.test.js
@@ -5,13 +5,38 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var mbtile = path.join(__dirname, '/fixtures/missingdestination.mbtiles');
-var opts = {
-  bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
-  zoom: zoom
-};
 
 test('missingDestination', function(t) {
   t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.missingDestination(opts, mbtile, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs[0]);
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'LineString',
+      'Should be LineString'
+    );
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'missingdestination',
+      'Should be missingdestination'
+    );
+    t.end();
+  });
+});
+
+test('missingDestination -- postProcess', function(t) {
+  t.plan(2);
+  var opts = {
+    bbox: [-122.6663, 37.098181, -121.39189, 37.969373],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.missingDestination(opts, mbtile, function() {
     var logs = logInterceptor.end();

--- a/test/missingOneways.test.js
+++ b/test/missingOneways.test.js
@@ -8,13 +8,52 @@ var missingOnewaysTiles = path.join(
   __dirname,
   '/fixtures/missingOneways.mbtiles'
 );
-var missingOnewaysOpts = {
-  bbox: [-83.136978, 39.954228, -82.86232, 40.074656],
-  zoom: zoom
-};
 
 test('missingOneways', function(t) {
   t.plan(4);
+  var missingOnewaysOpts = {
+    bbox: [-83.136978, 39.954228, -82.86232, 40.074656],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.missingOneways(
+    missingOnewaysOpts,
+    missingOnewaysTiles,
+    function() {
+      var logs = logInterceptor.end();
+      var geoJSON = JSON.parse(logs);
+      t.equal(
+        geoJSON.features[0].properties._osmlint,
+        'missingoneways',
+        'Should be missingoneways'
+      );
+      t.equal(
+        geoJSON.features[0].geometry.type,
+        'LineString',
+        'Should be  LineString'
+      );
+      t.equal(
+        geoJSON.features[1].properties._osmlint,
+        'missingoneways',
+        'Should be missingoneways'
+      );
+      t.equal(
+        geoJSON.features[1].geometry.type,
+        'LineString',
+        'Should be  LineString'
+      );
+      t.end();
+    }
+  );
+});
+
+test('missingOneways -- postProcess', function(t) {
+  t.plan(4);
+  var missingOnewaysOpts = {
+    bbox: [-83.136978, 39.954228, -82.86232, 40.074656],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.missingOneways(
     missingOnewaysOpts,

--- a/test/mixedLayer.test.js
+++ b/test/mixedLayer.test.js
@@ -5,13 +5,13 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var mixedLayerTiles = path.join(__dirname, '/fixtures/mixedlayer.mbtiles');
-var mixedLayerOpts = {
-  bbox: [-75.584564, -10.275904, -74.373322, -9.2581718],
-  zoom: zoom
-};
 
 test('mixedLayer', function(t) {
   t.plan(2);
+  var mixedLayerOpts = {
+    bbox: [-75.584564, -10.275904, -74.373322, -9.2581718],
+    zoom: zoom
+  };
   logInterceptor();
   processors.mixedLayer(mixedLayerOpts, mixedLayerTiles, function() {
     var logs = logInterceptor.end();
@@ -25,6 +25,31 @@ test('mixedLayer', function(t) {
       geoJSON.features[0].geometry.type,
       'LineString',
       'Should be  LineString'
+    );
+    t.end();
+  });
+});
+
+test('mixedLayer -- postProcess', function(t) {
+  t.plan(2);
+  var mixedLayerOpts = {
+    bbox: [-75.584564, -10.275904, -74.373322, -9.2581718],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.mixedLayer(mixedLayerOpts, mixedLayerTiles, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs);
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'mixedlayer',
+      'Should be mixedlayer'
+    );
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'Point',
+      'Should be  Point'
     );
     t.end();
   });

--- a/test/overlapHighways.test.js
+++ b/test/overlapHighways.test.js
@@ -8,13 +8,13 @@ var overlapHighwaysTiles = path.join(
   __dirname,
   '/fixtures/overlapHighways.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
 
 test('overlapHighways', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
   logInterceptor();
   processors.overlapHighways(commonOpts, overlapHighwaysTiles, function() {
     var logs = logInterceptor.end();
@@ -28,6 +28,32 @@ test('overlapHighways', function(t) {
           'Should be overlaphighways'
         );
         t.equal(geoJSON.features[0].geometry.type, 'Point', 'Should be Point');
+      }
+    }
+    t.end();
+  });
+});
+
+test('overlapHighways -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.overlapHighways(commonOpts, overlapHighwaysTiles, function() {
+    var logs = logInterceptor.end();
+    for (var i = 0; i < logs.length; i++) {
+      var geoJSON = JSON.parse(logs[i]);
+      t.comment('Pass: ' + (i + 1));
+      if (geoJSON.features.length > 0) {
+        t.equal(
+          geoJSON.features[0].properties._osmlint,
+          'overlaphighways',
+          'Should be overlaphighways'
+        );
+        t.equal(geoJSON.features[0].geometry.type, 'MultiPoint', 'Should be MultiPoint');
       }
     }
     t.end();

--- a/test/punctuationCharactersHighways.test.js
+++ b/test/punctuationCharactersHighways.test.js
@@ -8,12 +8,47 @@ var signPuntuactionTiles = path.join(
   __dirname,
   '/fixtures/punctuationCharactersHighways.mbtiles'
 );
-var signPuntuactionOpts = {
-  bbox: [-123.05537, 44.026705, -123.02525, 44.047499],
-  zoom: zoom
-};
+
 test('punctuationCharactersHighways', function(t) {
   t.plan(2);
+  var signPuntuactionOpts = {
+    bbox: [-123.05537, 44.026705, -123.02525, 44.047499],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.punctuationCharactersHighways(
+    signPuntuactionOpts,
+    signPuntuactionTiles,
+    function() {
+      var logs = logInterceptor.end();
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        t.comment('Pass: ' + (i + 1));
+        if (geoJSON.features.length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'punctuationcharactershighways',
+            'Should be signPuntuaction'
+          );
+          t.equal(
+            geoJSON.features[0].geometry.type,
+            'LineString',
+            'Should be a lineString'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+test('punctuationCharactersHighways -- postProcess', function(t) {
+  t.plan(2);
+  var signPuntuactionOpts = {
+    bbox: [-123.05537, 44.026705, -123.02525, 44.047499],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.punctuationCharactersHighways(
     signPuntuactionOpts,

--- a/test/selfIntersectingHighways.test.js
+++ b/test/selfIntersectingHighways.test.js
@@ -8,13 +8,12 @@ var selfIntersectingHighwaysTiles = path.join(
   __dirname,
   '/fixtures/selfIntersectingHighways.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
-
 test('selfIntersectingHighways', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
   logInterceptor();
   processors.selfIntersectingHighways(
     commonOpts,
@@ -34,6 +33,40 @@ test('selfIntersectingHighways', function(t) {
             geoJSON.features[0].geometry.type,
             'Point',
             'Should be  LineString'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+test('selfIntersectingHighways -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.selfIntersectingHighways(
+    commonOpts,
+    selfIntersectingHighwaysTiles,
+    function() {
+      var logs = logInterceptor.end();
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        t.comment('Pass: ' + (i + 1));
+        if (geoJSON.features.length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'selfintersectinghighways',
+            'Should be selfintersecting'
+          );
+          t.equal(
+            geoJSON.features[0].geometry.type,
+            'MultiPoint',
+            'Should be  MultiPoint'
           );
         }
       }

--- a/test/separatorTokenDestination.test.js
+++ b/test/separatorTokenDestination.test.js
@@ -8,12 +8,46 @@ var separatorTokenTiles = path.join(
   __dirname,
   '/fixtures/separatorTokenDestination.mbtiles'
 );
-var separatorTokenOpts = {
-  bbox: [19.910831, 41.02741, 19.998722, 41.082296],
-  zoom: zoom
-};
 test('separatorTokenDestination', function(t) {
   t.plan(2);
+  var separatorTokenOpts = {
+    bbox: [19.910831, 41.02741, 19.998722, 41.082296],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.separatorToken(
+    separatorTokenOpts,
+    separatorTokenTiles,
+    function() {
+      var logs = logInterceptor.end();
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        t.comment('Pass: ' + (i + 1));
+        if (geoJSON.features.length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'separatortokendestination',
+            'Should be separatorTokenDestination'
+          );
+          t.equal(
+            geoJSON.features[0].geometry.type,
+            'LineString',
+            'Should be a lineString'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+test('separatorTokenDestination -- postProcess', function(t) {
+  t.plan(2);
+  var separatorTokenOpts = {
+    bbox: [19.910831, 41.02741, 19.998722, 41.082296],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.separatorToken(
     separatorTokenOpts,

--- a/test/strangeLayer.test.js
+++ b/test/strangeLayer.test.js
@@ -5,13 +5,37 @@ var path = require('path');
 var processors = require('../index.js');
 var zoom = 12;
 var strangelayerTiles = path.join(__dirname, '/fixtures/strangelayer.mbtiles');
-var optsStrangeLayer = {
-  bbox: [127.03491, 37.303279, 127.16228, 37.418163],
-  zoom: zoom
-};
 
 test('strangeLayer', function(t) {
   t.plan(2);
+  var optsStrangeLayer = {
+    bbox: [127.03491, 37.303279, 127.16228, 37.418163],
+    zoom: zoom
+  };
+  logInterceptor();
+  processors.strangeLayer(optsStrangeLayer, strangelayerTiles, function() {
+    var logs = logInterceptor.end();
+    var geoJSON = JSON.parse(logs);
+    t.equal(
+      geoJSON.features[0].properties._osmlint,
+      'strangelayer',
+      'Should be strangelayer'
+    );
+    t.equal(
+      geoJSON.features[0].geometry.type,
+      'LineString',
+      'Should be  LineString'
+    );
+  });
+});
+
+test('strangeLayer -- postProcess', function(t) {
+  t.plan(2);
+  var optsStrangeLayer = {
+    bbox: [127.03491, 37.303279, 127.16228, 37.418163],
+    zoom: zoom,
+    postProcess: true
+  };
   logInterceptor();
   processors.strangeLayer(optsStrangeLayer, strangelayerTiles, function() {
     var logs = logInterceptor.end();

--- a/test/unconnectedHighways.test.js
+++ b/test/unconnectedHighways.test.js
@@ -8,13 +8,13 @@ var unconnectedHighwaysTiles = path.join(
   __dirname,
   '/fixtures/unconnectedHighways.mbtiles'
 );
-var commonOpts = {
-  bbox: [-0.0878906, -0.0878906, 0, 0],
-  zoom: zoom
-};
 
 test('unconnectedHighways', function(t) {
   t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom
+  };
   logInterceptor();
   processors.unconnectedHighways(
     commonOpts,
@@ -34,6 +34,41 @@ test('unconnectedHighways', function(t) {
             geoJSON.features[0].geometry.type,
             'LineString',
             'Should be LineString'
+          );
+        }
+      }
+      t.end();
+    }
+  );
+});
+
+
+test('unconnectedHighways -- postProcess', function(t) {
+  t.plan(2);
+  var commonOpts = {
+    bbox: [-0.0878906, -0.0878906, 0, 0],
+    zoom: zoom,
+    postProcess: true
+  };
+  logInterceptor();
+  processors.unconnectedHighways(
+    commonOpts,
+    unconnectedHighwaysTiles,
+    function() {
+      var logs = logInterceptor.end();
+      for (var i = 0; i < logs.length; i++) {
+        var geoJSON = JSON.parse(logs[i]);
+        t.comment('Pass: ' + (i + 1));
+        if (geoJSON.features.length > 0) {
+          t.equal(
+            geoJSON.features[0].properties._osmlint,
+            'unconnectedhighways',
+            'Should be unconnectedhighways'
+          );
+          t.equal(
+            geoJSON.features[0].geometry.type,
+            'Point',
+            'Should be Point'
           );
         }
       }

--- a/validators/crossingHighways/index.js
+++ b/validators/crossingHighways/index.js
@@ -1,8 +1,11 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
+
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +16,17 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('reduce', function() {})
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/crossingHighways/postProcess.js
+++ b/validators/crossingHighways/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/crossingHighwaysBridges/index.js
+++ b/validators/crossingHighwaysBridges/index.js
@@ -1,8 +1,11 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
+
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +16,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/crossingHighwaysBridges/postProcess.js
+++ b/validators/crossingHighwaysBridges/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/crossingHighwaysBuildings/index.js
+++ b/validators/crossingHighwaysBuildings/index.js
@@ -1,8 +1,11 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
+
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +16,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/crossingHighwaysBuildings/postProcess.js
+++ b/validators/crossingHighwaysBuildings/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['MultiPoint']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/crossingWaterwaysHighways/index.js
+++ b/validators/crossingWaterwaysHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/crossingWaterwaysHighways/postProcess.js
+++ b/validators/crossingWaterwaysHighways/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/deprecatedConstructionProposalTag/index.js
+++ b/validators/deprecatedConstructionProposalTag/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/deprecatedConstructionProposalTag/postProcess.js
+++ b/validators/deprecatedConstructionProposalTag/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/duplicateWayNameRef/index.js
+++ b/validators/duplicateWayNameRef/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/duplicateWayNameRef/postProcess.js
+++ b/validators/duplicateWayNameRef/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/impossibleAngle/index.js
+++ b/validators/impossibleAngle/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/impossibleAngle/postProcess.js
+++ b/validators/impossibleAngle/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/impossibleOneWays/index.js
+++ b/validators/impossibleOneWays/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/impossibleOneWays/postProcess.js
+++ b/validators/impossibleOneWays/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/invalidDestination/index.js
+++ b/validators/invalidDestination/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/invalidDestination/postProcess.js
+++ b/validators/invalidDestination/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/invalidMotorwayJunctions/index.js
+++ b/validators/invalidMotorwayJunctions/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/invalidMotorwayJunctions/postProcess.js
+++ b/validators/invalidMotorwayJunctions/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/invalidTurnLanes/postProcess.js
+++ b/validators/invalidTurnLanes/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var toMultipointStream = post.createToMultipointStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(toMultipointStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/islandsHighways/index.js
+++ b/validators/islandsHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/islandsHighways/postProcess.js
+++ b/validators/islandsHighways/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['LineString']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/missingCardinalDestination/index.js
+++ b/validators/missingCardinalDestination/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/missingCardinalDestination/postProcess.js
+++ b/validators/missingCardinalDestination/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/missingDestination/index.js
+++ b/validators/missingDestination/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/missingDestination/postProcess.js
+++ b/validators/missingDestination/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/missingOneways/index.js
+++ b/validators/missingOneways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/missingOneways/postProcess.js
+++ b/validators/missingOneways/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['LineString']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/mixedLayer/index.js
+++ b/validators/mixedLayer/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/mixedLayer/postProcess.js
+++ b/validators/mixedLayer/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/overlapHighways/index.js
+++ b/validators/overlapHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/overlapHighways/postProcess.js
+++ b/validators/overlapHighways/postProcess.js
@@ -1,0 +1,17 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var mergeByIdStream = post.createMergeByIdStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(mergeByIdStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/punctuationCharactersHighways/index.js
+++ b/validators/punctuationCharactersHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/punctuationCharactersHighways/postProcess.js
+++ b/validators/punctuationCharactersHighways/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/selfIntersectingHighways/index.js
+++ b/validators/selfIntersectingHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/selfIntersectingHighways/postProcess.js
+++ b/validators/selfIntersectingHighways/postProcess.js
@@ -1,0 +1,17 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point', 'MultiPoint']);
+  var mergeByIdStream = post.createMergeByIdStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(mergeByIdStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/separatorTokenDestination/index.js
+++ b/validators/separatorTokenDestination/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/separatorTokenDestination/postProcess.js
+++ b/validators/separatorTokenDestination/postProcess.js
@@ -1,0 +1,13 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/strangeLayer/postProcess.js
+++ b/validators/strangeLayer/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var toMultiPointStream = post.createToMultipointStream();
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(toMultiPointStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};

--- a/validators/unconnectedHighways/index.js
+++ b/validators/unconnectedHighways/index.js
@@ -1,8 +1,10 @@
 'use strict';
 var tileReduce = require('@mapbox/tile-reduce');
 var path = require('path');
+var postProcess = require('./postProcess');
 
 module.exports = function(opts, mbtilesPath, callback) {
+  var outputStream =  opts.postProcess ? postProcess() : process.stdout;
   tileReduce({
     bbox: opts.bbox,
     zoom: opts.zoom,
@@ -13,10 +15,16 @@ module.exports = function(opts, mbtilesPath, callback) {
         mbtiles: mbtilesPath,
         raw: false
       }
-    ]
+    ],
+    output: outputStream
   })
-    .on('reduce', function() {})
-    .on('end', function() {
+  .on('end', function() {
+    if (opts.postProcess) {
+      callback && outputStream.on('end', function() {
+        setTimeout(callback, 0);
+      });
+    } else {
       callback && callback();
-    });
+    }
+  });
 };

--- a/validators/unconnectedHighways/postProcess.js
+++ b/validators/unconnectedHighways/postProcess.js
@@ -1,0 +1,15 @@
+'use strict';
+var post = require('../../lib/postProcessing');
+
+module.exports = function postProcess() {
+  var lineStream = post.createReadlineStream();
+  var filterStream = post.createGeometryFilterTypeStream(['Point']);
+  var convertStream = post.createConvertToGeojsonStream();
+
+  lineStream
+    .pipe(filterStream)
+    .pipe(convertStream)
+    .pipe(process.stdout);
+
+  return lineStream;
+};


### PR DESCRIPTION
closes #280

This adds an optional `postProcess` flag to linters. When set to true it will run opinionated post processing steps with the goal of simplifying output to make identifying errors easier.